### PR TITLE
Update @expo/config-plugins to version required by non-deprecated Expo SDK (>46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "readmeFilename": "README.md",
     "homepage": "https://github.com/urbanairship/airship-expo-plugin",
     "dependencies": {
-      "@expo/config-plugins": "^4.0.14",
+      "@expo/config-plugins": "^7.2.5",
       "@expo/image-utils": "^0.3.18"
     },
     "devDependencies": {


### PR DESCRIPTION
`expo doctor` command is throwing a `stderr` due to outdated dependencies for the installed Expo SDK (in this case, 49), which his update should resolve, though I'm not personally aware of what build pipeline you use and so `yarn.lock` may need modification.

Can be asserted by running `npm why @expo/config-plugins`
```
@expo/config-plugins@4.1.5
node_modules/airship-expo-plugin/node_modules/@expo/config-plugins
  @expo/config-plugins@"^4.0.14" from airship-expo-plugin@1.0.0
  node_modules/airship-expo-plugin
    airship-expo-plugin@"^1.0.0" from the root project
```

<img width="810" alt="Screenshot 2023-09-26 at 09 51 44" src="https://github.com/urbanairship/airship-expo-plugin/assets/1196144/0a4368c6-6464-427d-8ce5-c22947945e39">
