### PR TITLE
Update package.json for expo@51.0.0 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "readmeFilename": "README.md",
   "homepage": "https://github.com/urbanairship/airship-expo-plugin",
   "dependencies": {
-    "@expo/config-plugins": "^7.2.5",
+    "@expo/config-plugins": "^8.0.4",
     "@expo/image-utils": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Updates an expo core package dependency.

### Why are these changes necessary?
Because `@expo/config-plugins@7.2.5` throws an error during the `expo-doctor` stage and `@expo/config-plugins@8.0.4` is the latest compatible version.

```
✔ Check Expo config for common issues
✔ Check package.json for common issues
✔ Check native tooling versions
✔ Check dependencies for packages that should not be installed directly
✔ Check for common project setup issues
✔ Check for issues with metro config
✔ Check npm/ yarn versions
✔ Check Expo config (app.json/ app.config.js) schema
✖ Check that packages match versions required by installed Expo SDK
✔ Check for legacy global CLI installed locally
✔ Check that native modules do not use incompatible support packages
✔ Check that native modules use compatible support package versions for installed Expo SDK

Detailed check results:

Expected package @expo/config-plugins@~8.0.0
Found invalid:
  @expo/config-plugins@7.2.5
  ```