### PR TITLE
Update @expo/config-plugins dependency for Expo SDK 52

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "readmeFilename": "README.md",
   "homepage": "https://github.com/urbanairship/airship-expo-plugin",
   "dependencies": {
-    "@expo/config-plugins": "^8.0.4",
+    "@expo/config-plugins": "^9.0.12",
     "@expo/image-utils": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Updates `@expo/config-plugins` dependency to the latest for compatibility with Expo SDK 52

### Why are these changes necessary?
When upgrading to Expo SDK 52, `expo-doctor` throws the following warning:

![CleanShot 2024-12-19 at 08 22 31@2x](https://github.com/user-attachments/assets/e47662e7-8727-4561-8208-29ce2cb8c271)

Running `yarn why` revealed `airship-expo-plugin` as the source:

![CleanShot 2024-12-19 at 08 45 26@2x](https://github.com/user-attachments/assets/fafb6f7f-01e9-4d37-9dd3-323b53626bcd)


### How did you verify these changes?
Checked changelog and verified no breaking changes 
https://github.com/expo/expo/blob/main/packages/%40expo/config-plugins/CHANGELOG.md#9012---2024-12-05
