### PR TITLE
[MOBILE-4912] adds a deploymentTarget field that defaults to iOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Airship Expo Plugin Changelog
 
+## Version 2.0.0 - Febrary 05, 2024
+Major version that adds support for the Airship ReactNative SDK 21. The min deployment target is now iOS 15.
+
 ## Version 1.4.0 - December 20, 2024
 Minor version that adds support for Aiship Plugin Extender.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Airship Expo Plugin Changelog
 
-## Version 2.0.0 - Febrary 05, 2024
+## Version 2.0.0 - Febrary 05, 2025
 Major version that adds support for the Airship ReactNative SDK 21. The min deployment target is now iOS 15.
 
 ## Version 1.4.0 - December 20, 2024

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Airship [Expo Config Plugin](https://docs.expo.dev/guides/config-plugins/). This
 
 ```sh
 expo install airship-expo-plugin
-yarn add urbanairship-react-native
+yarn add @ua/react-native-airship
 ```
 
 ### Configuring the plugin
@@ -29,6 +29,7 @@ Add the plugin to the app.json:
           "notificationServiceInfo": "./assets/NotificationServiceExtension-Info.plist",
           "notificationServiceTargetName": "NotificationServiceExtension",
           "developmentTeamID": "MY_TEAM_ID",
+          "deploymentTarget": "15.0",
           "airshipExtender": "./assets/AirshipPluginExtender.swift"
         }
       }
@@ -47,6 +48,7 @@ iOS Config:
 - notificationServiceInfo: Optional. Airship will use a default one if not provided. The local path to a Notification Service Extension Info.plist.
 - notificationServiceTargetName: Optional. Defaults to NotificationServiceExtension if not provided.
 - developmentTeamID: Optional. The Apple Development Team ID used to configure the Notification Service Extension target.
+- deploymentTarget: Optional. The minimum Deployment Target version used to configure the Notification Service Extension target.
 - airshipExtender: Optional. The local path to a AirshipPluginExtender.swift file.
 
 ## Calling takeOff

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ iOS Config:
 - notificationServiceInfo: Optional. Airship will use a default one if not provided. The local path to a Notification Service Extension Info.plist.
 - notificationServiceTargetName: Optional. Defaults to NotificationServiceExtension if not provided.
 - developmentTeamID: Optional. The Apple Development Team ID used to configure the Notification Service Extension target.
-- deploymentTarget: Optional. The minimum Deployment Target version used to configure the Notification Service Extension target.
+- deploymentTarget: Optional. The minimum Deployment Target version used to configure the Notification Service Extension target. Defaults to iOS 15.
 - airshipExtender: Optional. The local path to a AirshipPluginExtender.swift file.
 
 ## Calling takeOff

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airship-expo-plugin",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Airship Expo config plugin",
   "main": "./app.plugin.js",
   "scripts": {

--- a/plugin/src/withAirship.ts
+++ b/plugin/src/withAirship.ts
@@ -44,6 +44,10 @@ export type AirshipIOSPluginProps = {
    */
   developmentTeamID?: string;
   /**
+   * Optional. The minimum Deployment Target version used to configure the Notification Service Extension target.
+   */
+  deploymentTarget?: string;
+  /**
    * Optional. The local path to a AirshipPluginExtender.swift file.
    */
   airshipExtender?: string;

--- a/plugin/src/withAirship.ts
+++ b/plugin/src/withAirship.ts
@@ -45,6 +45,7 @@ export type AirshipIOSPluginProps = {
   developmentTeamID?: string;
   /**
    * Optional. The minimum Deployment Target version used to configure the Notification Service Extension target.
+   * Defaults to iOS 15.
    */
   deploymentTarget?: string;
   /**

--- a/plugin/src/withAirshipIOS.ts
+++ b/plugin/src/withAirshipIOS.ts
@@ -167,7 +167,7 @@ const withExtensionTargetInXcodeProject: ConfigPlugin<AirshipIOSPluginProps> = (
         && configurations[key].buildSettings.PRODUCT_NAME == `"${targetName}"`
       ) {
         const buildSettingsObj = configurations[key].buildSettings;
-        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = "14.0";
+        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = props.deploymentTarget ?? "15.0";
         buildSettingsObj.SWIFT_VERSION = "5.0";
         buildSettingsObj.DEVELOPMENT_TEAM = props?.developmentTeamID;
         buildSettingsObj.CODE_SIGN_STYLE = "Automatic";


### PR DESCRIPTION
This is to support SDK 19.
Adds a deploymentTarget field that defaults to iOS 15. 
No update for the Android part, the compileSdkVersion is updated in an expo way.