### PR TITLE
Update @expo/config-plugins dependency for Expo SDK 53

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "readmeFilename": "README.md",
   "homepage": "https://github.com/urbanairship/airship-expo-plugin",
   "dependencies": {
-    "@expo/config-plugins": "^9.0.12",
+    "@expo/config-plugins": "^10.0.2",
     "@expo/image-utils": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Updates `@expo/config-plugins` dependency to the latest for compatibility with Expo SDK 53

### Why are these changes necessary?
When upgrading to Expo SDK 53, expo-doctor throws the following warning:

![image](https://github.com/user-attachments/assets/bcc1ef37-8f3e-4b34-a9d4-db8676184476)

